### PR TITLE
for laravel11 and PHPUnit11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ phpunit-ci.xml
 /.php-cs-fixer.cache
 /.phpstan
 /.fixer-diff.status
-composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit-ci.xml
 /.php-cs-fixer.cache
 /.phpstan
 /.fixer-diff.status
+composer.lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -148,7 +148,9 @@ return (new PhpCsFixer\Config())
         ],
 
         // Developer decides strictness of assert method
-        'php_unit_strict' => [],
+        'php_unit_strict' => [
+            'assertions' => [],
+        ],
 
         // Developer decides strictness of comparison
         'strict_comparison' => false,

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "version": "0.0.5",
     "require": {
         "php": "^8.2|^8.3",
-        "illuminate/console": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
-        "illuminate/validation": "^9.0|^10.0",
+        "illuminate/console": "^11.0",
+        "illuminate/support": "^11.0",
+        "illuminate/validation": "^11.0",
         "nette/php-generator": "^4.1",
         "zircote/swagger-php": "^4.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.46",
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.0|^10.0",
+        "phpunit/phpunit": "^10.0",
         "smeghead/php-vendor-credits": "^0.0.5",
         "spaze/phpstan-disallowed-calls": "^3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "friendsofphp/php-cs-fixer": "^3.46",
         "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^11.0",
         "smeghead/php-vendor-credits": "^0.0.5",
         "spaze/phpstan-disallowed-calls": "^3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "friendsofphp/php-cs-fixer": "^3.46",
         "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.2",
         "smeghead/php-vendor-credits": "^0.0.5",
         "spaze/phpstan-disallowed-calls": "^3.1"
     },

--- a/src/Http/Requests/FormRequestPropertyHandlerTrait.php
+++ b/src/Http/Requests/FormRequestPropertyHandlerTrait.php
@@ -11,6 +11,7 @@ use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionType;
 use ReflectionException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * If the OpenApi attribute is embedded in the form request class along  with the Property addition,
@@ -32,6 +33,12 @@ trait FormRequestPropertyHandlerTrait
         $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
 
         foreach ($properties as $property) {
+
+            // from laravel11, Symfony components come here.
+            if ($property->class === Request::class) {
+                continue;
+            }
+
             // Only primitive types take over parameters
             if (!$property->hasType()) {
                 continue;

--- a/tests/Unit/FormRequestPropertyHandlerTraitTest.php
+++ b/tests/Unit/FormRequestPropertyHandlerTraitTest.php
@@ -4,19 +4,25 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Litalico\EgR2\Exceptions\InvalidOpenApiDefinitionException;
 use Litalico\EgR2\Http\Requests\FormRequestPropertyHandlerTrait;
+use Litalico\EgR2\Rules\Integer;
 use Mockery;
 use OpenApi\Attributes\Property;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionException;
 use Tests\FullAccessWrapper;
 use Tests\TestCase;
 
 /**
  * @package Tests\Unit
- * @coversDefaultClass \Litalico\EgR2\Http\Requests\FormRequestPropertyHandlerTrait
- * @covers \Litalico\EgR2\Http\Requests\FormRequestPropertyHandlerTrait
- * @covers \Litalico\EgR2\Rules\Integer
- * @covers \Litalico\EgR2\Exceptions\InvalidOpenApiDefinitionException
  */
+#[CoversTrait(FormRequestPropertyHandlerTrait::class)]
+#[CoversClass(InvalidOpenApiDefinitionException::class)]
+#[CoversClass(Integer::class)]
 class FormRequestPropertyHandlerTraitTest extends TestCase
 {
     public static function setUpBeforeClass(): void
@@ -24,9 +30,9 @@ class FormRequestPropertyHandlerTraitTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::passedValidation
+     * @throws ReflectionException
      */
+    #[Test]
     public function testPropertyOfFormRequestCanBeInitializedEvenIfValueIsNull(): void
     {
         setup:
@@ -93,9 +99,9 @@ class FormRequestPropertyHandlerTraitTest extends TestCase
 
 
     /**
-     * @test
-     * @covers ::passedValidation
+     * @throws ReflectionException
      */
+    #[Test]
     public function testGetPropertiesOfNestedObject(): void
     {
         setup:
@@ -138,9 +144,9 @@ class FormRequestPropertyHandlerTraitTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::passedValidation
+     * @throws ReflectionException
      */
+    #[Test]
     public function testGetNestedObjectPropertiesEvenIfValueIsNull(): void
     {
         setup:
@@ -181,14 +187,13 @@ class FormRequestPropertyHandlerTraitTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::passedValidation
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
+    #[Test]
     public function testNestedObject(): void
     {
         setup:
-        $requestMock = Mockery::mock('Illuminate\Http\Request');
+        $requestMock = Mockery::mock(Request::class);
         $requestMock->shouldReceive('setUserResolver')->andReturn("dummy");
         $requestMock->shouldReceive('all')->andReturn(['id' => 1, 'nested' => ['id' => 2, 'name' => 'bob']]);
         $this->app->instance('request', $requestMock);

--- a/tests/Unit/NameSpaceFindServiceTest.php
+++ b/tests/Unit/NameSpaceFindServiceTest.php
@@ -9,13 +9,12 @@ use Illuminate\Foundation\Application;
 use Litalico\EgR2\Console\Commands\GenerateRoute;
 use Litalico\EgR2\Providers\GenerateRouteServiceProvider;
 use Litalico\EgR2\Services\NameSpaceFindService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-/**
- * @package Tests\Unit
- * @coversDefaultClass \Litalico\EgR2\Services\NameSpaceFindService
- * @covers \Litalico\EgR2\Services\NameSpaceFindService
- */
+#[CoversClass(NameSpaceFindService::class)]
 class NameSpaceFindServiceTest extends TestCase
 {
     public static function setUpBeforeClass(): void
@@ -23,15 +22,18 @@ class NameSpaceFindServiceTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::getNameSpaces
      * @throws
      */
-    public function testGetNameSpaces(): void
+    #[Test]
+    public function getNameSpaces(): void
     {
         setup:
         // Change base path
-        new Application(realpath(__DIR__.'/../../'));
+        $path = realpath(__DIR__.'/../../');
+        if ($path === false) {
+            self::fail('realpath is invalid');
+        }
+        new Application($path);
         $instance = new NameSpaceFindService();
 
         when:
@@ -42,17 +44,20 @@ class NameSpaceFindServiceTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::getClassesOfNameSpace
-     * @dataProvider namespacePattern
      * @param string $namespace
-     * @param array $expected
+     * @param list<class-string> $expected
      */
-    public function testGetClassesOfNameSpace(string $namespace, array $expected): void
+    #[Test]
+    #[DataProvider('namespacePattern')]
+    public function getClassesOfNameSpace(string $namespace, array $expected): void
     {
         setup:
         // Change base path
-        new Application(realpath(__DIR__.'/../../'));
+        $path = realpath(__DIR__.'/../../');
+        if ($path === false) {
+            self::fail('realpath is invalid');
+        }
+        new Application($path);
         $instance = new NameSpaceFindService();
 
         when:

--- a/tests/Unit/RequestRuleGeneratorTraitTest.php
+++ b/tests/Unit/RequestRuleGeneratorTraitTest.php
@@ -14,6 +14,7 @@ use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Parameter;
 use OpenApi\Attributes\Property;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionException;
@@ -23,7 +24,7 @@ use Tests\TestCase;
 /**
  * Testing of Validation Rule Generation Trait
  */
-#[CoversClass(RequestRuleGeneratorTrait::class)]
+#[CoversTrait(RequestRuleGeneratorTrait::class)]
 #[CoversClass(Integer::class)]
 class RequestRuleGeneratorTraitTest extends TestCase
 {

--- a/tests/Unit/RequestRuleGeneratorTraitTest.php
+++ b/tests/Unit/RequestRuleGeneratorTraitTest.php
@@ -541,10 +541,7 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     * @covers ::convertRule
-     */
+    #[Test]
     public function testNestedSchemasCanBeConverted(): void
     {
         setup:

--- a/tests/Unit/RequestRuleGeneratorTraitTest.php
+++ b/tests/Unit/RequestRuleGeneratorTraitTest.php
@@ -34,8 +34,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
     /**
      * @param Schema $property
      * @param array $expected
-     *
-     * @test
      */
     #[Test]
     #[DataProvider('singlePropertyConversionPattern')]
@@ -90,9 +88,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function objectRequiredFieldsCanBeConverted(): void
     {
@@ -141,9 +136,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function requiredOnlyIfTheParentElementExists(): void
     {
@@ -180,9 +172,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
     #[Test]
     #[DataProvider('schemaDefinitionPropertyPattern')]
     #[DataProvider('schemaDefinitionParameterPattern')]
@@ -327,9 +316,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function arrayRequiredFieldsCanBeConverted(): void
     {
@@ -372,9 +358,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertEqualsCanonicalizing($expected, $actual);
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function multiTieredPropertiesCanBeConverted(): void
     {
@@ -441,9 +424,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function combinationOfParameterAndSchemaCanBeConverted(): void
     {
@@ -474,9 +454,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /**
-     * @test
-     */
     #[Test]
     public function allowsRulesToBeSpecifiedForAllElementsOfAChildElementOfAnArrayOmittingThePropertyName(): void
     {
@@ -535,8 +512,6 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @throws ReflectionException
-     *
-     * @test
      */
     #[Test]
     public function propertyAndSchemaCombinationsCanBeConverted(): void

--- a/tests/Unit/RequestRuleGeneratorTraitTest.php
+++ b/tests/Unit/RequestRuleGeneratorTraitTest.php
@@ -13,18 +13,18 @@ use OpenApi\Annotations\Schema;
 use OpenApi\Attributes\Items;
 use OpenApi\Attributes\Parameter;
 use OpenApi\Attributes\Property;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use ReflectionException;
 use Tests\FullAccessWrapper;
 use Tests\TestCase;
 
 /**
  * Testing of Validation Rule Generation Trait
- * @package Tests\Unit
- * @coversDefaultClass \Litalico\EgR2\Http\Requests\RequestRuleGeneratorTrait
- * @covers \Litalico\EgR2\Http\Requests\RequestRuleGeneratorTrait
- * @covers \Litalico\EgR2\Rules\Integer
- * @covers \Litalico\EgR2\Exceptions\InvalidOpenApiDefinitionException
  */
+#[CoversClass(RequestRuleGeneratorTrait::class)]
+#[CoversClass(Integer::class)]
 class RequestRuleGeneratorTraitTest extends TestCase
 {
     public static function setUpBeforeClass(): void
@@ -32,13 +32,14 @@ class RequestRuleGeneratorTraitTest extends TestCase
     }
 
     /**
-     * @test
-     * @dataProvider singlePropertyConversionPattern
-     * @covers ::convertRule
      * @param Schema $property
      * @param array $expected
+     *
+     * @test
      */
-    public function testCanConvertOpenApiSchemaToLaravelRules(Schema $property, array $expected): void
+    #[Test]
+    #[DataProvider('singlePropertyConversionPattern')]
+    public function canConvertOpenApiSchemaToLaravelRules(Schema $property, array $expected): void
     {
         setup:
         $class = new class extends FormRequest
@@ -91,9 +92,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testObjectRequiredFieldsCanBeConverted(): void
+    #[Test]
+    public function objectRequiredFieldsCanBeConverted(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -142,9 +143,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testRequiredOnlyIfTheParentElementExists(): void
+    #[Test]
+    public function requiredOnlyIfTheParentElementExists(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -181,11 +182,11 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
-     * @dataProvider schemaDefinitionPropertyPattern
-     * @dataProvider schemaDefinitionParameterPattern
      */
-    public function testErrorOccursIfThereIsAConflictBetweenPropertyAndSchemaDefinition(FormRequest $instance, string $expectedMessage): void
+    #[Test]
+    #[DataProvider('schemaDefinitionPropertyPattern')]
+    #[DataProvider('schemaDefinitionParameterPattern')]
+    public function errorOccursIfThereIsAConflictBetweenPropertyAndSchemaDefinition(FormRequest $instance, string $expectedMessage): void
     {
         expect:
         $this->expectException(InvalidOpenApiDefinitionException::class);
@@ -328,9 +329,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testArrayRequiredFieldsCanBeConverted(): void
+    #[Test]
+    public function arrayRequiredFieldsCanBeConverted(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -373,9 +374,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testMultiTieredPropertiesCanBeConverted(): void
+    #[Test]
+    public function multiTieredPropertiesCanBeConverted(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -442,9 +443,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testCombinationOfParameterAndSchemaCanBeConverted(): void
+    #[Test]
+    public function combinationOfParameterAndSchemaCanBeConverted(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -475,9 +476,9 @@ class RequestRuleGeneratorTraitTest extends TestCase
 
     /**
      * @test
-     * @covers ::convertRule
      */
-    public function testAllowsRulesToBeSpecifiedForAllElementsOfAChildElementOfAnArrayOmittingThePropertyName(): void
+    #[Test]
+    public function allowsRulesToBeSpecifiedForAllElementsOfAChildElementOfAnArrayOmittingThePropertyName(): void
     {
         setup:
         $class = new class extends FormRequest
@@ -533,11 +534,12 @@ class RequestRuleGeneratorTraitTest extends TestCase
     }
 
     /**
-     * @test
-     * @covers ::convertRule
      * @throws ReflectionException
+     *
+     * @test
      */
-    public function testPropertyAndSchemaCombinationsCanBeConverted(): void
+    #[Test]
+    public function propertyAndSchemaCombinationsCanBeConverted(): void
     {
         setup:
         $class = new ForClassSchemaAndPropertyTest();


### PR DESCRIPTION
# Goal
- upgrade to Laravel11 and PHPUnit11

# What I did
Ignore Symfony\Component\HttpFoundation\Request on passedValidation method FormRequestPropertyHandlerTrait. From Laravel 11, Symfony\Component\HttpFoundation\Request class becomes public property in FormRequest class