### PR TITLE
Fix no license information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "library",
     "description": "Easy request validation and route generation from open API specifications (for Laravel)",
     "version": "1.0.0",
+    "license": ["MIT"],
     "require": {
         "php": "^8.2|^8.3",
         "illuminate/console": "^11.0",


### PR DESCRIPTION
https://packagist.org/packages/litalico-engineering/eg-r2

<img width="803" alt="image" src="https://github.com/user-attachments/assets/9f4faa71-c47e-4cff-a5bc-6f3c7e51a58e">

The license file existed, but the composer.json did not seem to specify the license.