### PR TITLE
Add export-ignore for rector.php and Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@
 /.tagpr export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml export-ignore
+/rector.php export-ignore
+/Makefile export-ignore


### PR DESCRIPTION
With this PR, The archive targets other than src/ will be as follows:

```
 gh api repos/sasezaki/eg-r2/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src
CHANGELOG.md
CREDITS
LICENSE
README.md
composer.json
stubs/
stubs/config/
stubs/config/eg_r2.php
````