### PR TITLE
Drop Laravel 11 support and migrate compatibility baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,13 +37,11 @@ jobs:
     strategy:
       matrix:
         php: ["8.2", "8.3", "8.4", "8.5"]
-        laravel: ["11.*", "12.*", "13.*"]
+        laravel: ["12.*", "13.*"]
         swagger_php: ["^4.0", "^5.0", "^6.0"]
         exclude:
           - php: "8.2"
             laravel: "13.*"
-          - php: "8.5"
-            laravel: "11.*"
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         "zircote/swagger-php": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "v3.94.2",
+        "friendsofphp/php-cs-fixer": "v3.95.12",
         "orchestra/testbench": "^10.0|^11.0",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^11.0|^12.0|^13.0",
-        "rector/rector": "2.3.8",
+        "rector/rector": "2.5.5",
         "smeghead/php-vendor-credits": "^0.0.5",
-        "spaze/phpstan-disallowed-calls": "^4.5"
+        "spaze/phpstan-disallowed-calls": "^4.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
     "license": ["MIT"],
     "require": {
         "php": "^8.2|^8.3|^8.4|^8.5",
-        "illuminate/console": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0",
-        "illuminate/validation": "^11.0|^12.0|^13.0",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/validation": "^12.0|^13.0",
         "nette/php-generator": "^4.1",
         "zircote/swagger-php": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "v3.94.2",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.0|^12.0|^13.0",
         "rector/rector": "2.3.8",

--- a/src/Console/Commands/GenerateRoute.php
+++ b/src/Console/Commands/GenerateRoute.php
@@ -252,7 +252,6 @@ class GenerateRoute extends Command
     }
 
     /**
-     * @param mixed $scopes
      * @return list<string>
      */
     private function normalizeScopes(mixed $scopes): array

--- a/src/Http/Requests/FormRequestPropertyHandlerTrait.php
+++ b/src/Http/Requests/FormRequestPropertyHandlerTrait.php
@@ -62,7 +62,6 @@ trait FormRequestPropertyHandlerTrait
      * Values are normalized to match the declared property type.
      *
      * @param ReflectionProperty $property
-     * @return mixed
      * @throws ReflectionException
      */
     private function getDefaultValueFromProperty(ReflectionProperty $property): mixed
@@ -98,7 +97,6 @@ trait FormRequestPropertyHandlerTrait
      * Get the default value from the Property attribute if it exists.
      *
      * @param ReflectionProperty $property
-     * @return mixed
      */
     private function getPropertyDefaultValue(ReflectionProperty $property): mixed
     {
@@ -119,9 +117,7 @@ trait FormRequestPropertyHandlerTrait
     /**
      * Normalize a value to match the declared property type.
      *
-     * @param mixed $value
      * @param ReflectionType|null $type
-     * @return mixed
      */
     private function normalizeValueToType(mixed $value, ReflectionType|null $type): mixed
     {
@@ -153,7 +149,6 @@ trait FormRequestPropertyHandlerTrait
 
     /**
      * @param ReflectionType|null $type
-     * @return mixed
      * @throws ReflectionException
      */
     private function initialValue(?ReflectionType $type): mixed

--- a/src/Http/Requests/RequestAttributesGeneratorTrait.php
+++ b/src/Http/Requests/RequestAttributesGeneratorTrait.php
@@ -418,7 +418,6 @@ trait RequestAttributesGeneratorTrait
      *
      * OpenAPI library uses Generator::UNDEFINED as a sentinel for unset values.
      *
-     * @param mixed $value
      * @return bool
      */
     private function isDefined(mixed $value): bool

--- a/src/Rules/Integer.php
+++ b/src/Rules/Integer.php
@@ -17,7 +17,6 @@ class Integer implements ValidationRule
      * Run the validation rule.
      *
      * @param string $attribute
-     * @param mixed $value
      * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void


### PR DESCRIPTION
## Summary
- drop Laravel 11 support from package constraints
- align CI matrix to test only Laravel 12/13
- update dev tooling constraints in composer.json

## Changes
- illuminate/*: ^12.0|^13.0
- orchestra/testbench: ^10.0|^11.0
- test workflow matrix: remove 11.*
- bump dev tools: php-cs-fixer/phpstan/rector/phpstan-disallowed-calls

## Related Issue
- closes #55

## Validation
- make lint-all (local)
