### PR TITLE
Fix route name generation for route cache compatibility

### DIFF
--- a/src/Console/Commands/GenerateRoute.php
+++ b/src/Console/Commands/GenerateRoute.php
@@ -28,6 +28,7 @@ use function is_array;
 use function is_string;
 use function sprintf;
 use function str_contains;
+use function str_ends_with;
 use function trim;
 
 /**
@@ -100,6 +101,8 @@ class GenerateRoute extends Command
                 throw new RuntimeException($message);
             }
             $controllers = $this->nameSpaceFindService->getClassesOfNameSpace($namespaceName);
+            // Ensure Route::as() prefix composes hierarchical names with ->name().
+            $group = $this->normalizeRouteNameGroup($group);
 
             $closure = new Closure();
             $bodies = '';
@@ -127,6 +130,28 @@ class GenerateRoute extends Command
         fclose($this->fp);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Normalizes the route name group prefix for Route::as().
+     *
+     * Laravel concatenates Route::as() and ->name() literally, so we ensure
+     * the group ends with '.' to keep names hierarchical (e.g. api.users.index).
+     *
+     * @param string $group
+     * @return string
+     */
+    private function normalizeRouteNameGroup(string $group): string
+    {
+        if ($group === '') {
+            return '';
+        }
+
+        if (str_ends_with($group, '.')) {
+            return $group;
+        }
+
+        return "{$group}.";
     }
 
     /**

--- a/tests/Unit/GenerateRouteCommandTest.php
+++ b/tests/Unit/GenerateRouteCommandTest.php
@@ -210,6 +210,32 @@ class GenerateRouteCommandTest extends TestCase
         self::assertStringContainsString("Route::put('/resources/{id}','update')->name('updateResource');", $contents);
     }
 
+    #[Test]
+    public function it_normalizes_route_name_group_with_trailing_dot(): void
+    {
+        $routePath = $this->prepareRoutePath();
+        $namespace = 'Tests\\Fixtures\\Security';
+
+        $service = Mockery::mock(NameSpaceFindService::class);
+        $service->shouldReceive('getClassesOfNameSpace')
+            ->once()
+            ->with($namespace)
+            ->andReturn([ResourceController::class]);
+
+        $this->app->instance(NameSpaceFindService::class, $service);
+
+        $this->app['config']->set('eg_r2.route_path', $routePath);
+        $this->app['config']->set('eg_r2.namespaces', ['api' => $namespace]);
+        $this->app['config']->set('eg_r2.security', ['mapping' => [], 'undefined_scheme_policy' => 'ignore']);
+
+        $this->artisan('eg-r2:generate-route')->assertExitCode(0);
+
+        $contents = (string) file_get_contents($routePath);
+
+        self::assertStringContainsString("Route::as('api.')->group(function ()", $contents);
+        self::assertStringNotContainsString("Route::as('api')->group(function ()", $contents);
+    }
+
     /**
      * @param list<class-string> $controllers
      * @param array<string, mixed> $security


### PR DESCRIPTION
## Summary
- normalize route name group prefixes so generated Route::as(...) always composes hierarchical names
- add normalizeRouteNameGroup() documentation and call-site comment for maintainability
- add a regression test for namespace groups without a trailing dot

## Why
In no-dev/production-like environments, route cache generation can be affected when Route::as(...) does not end with a dot and is concatenated with ->name(...).

## Test
- ./vendor/bin/phpunit tests/Unit/GenerateRouteCommandTest.php
- ./vendor/bin/phpunit

Closes #58